### PR TITLE
Added support for BCM2711 (RPi4/400) pullups

### DIFF
--- a/db9_gpio_rpi-1.2/db9_gpio_rpi.c
+++ b/db9_gpio_rpi-1.2/db9_gpio_rpi.c
@@ -877,6 +877,7 @@ static int __init db9_init(void)
 {
 	/* Get the BCM2708 peripheral address base */
 	db9_bcm2708_peri_base = db9_bcm_peri_address_probe();
+	db9_bcm_model = db9_bcm_model_probe();
 	if (!db9_bcm2708_peri_base) {
 		pr_err("failed to find peripherals address base via device-tree\n");
 		return -ENODEV;

--- a/db9_gpio_rpi-1.2/db9_gpio_rpi.c
+++ b/db9_gpio_rpi-1.2/db9_gpio_rpi.c
@@ -738,9 +738,9 @@ static int __init db9_setup_pad(struct db9 *db9, int idx, int mode)
 	/* Activate pull-ups on inputs */
 	if (db9_bcm_model == 2711)
 	{
+		pr_info("Using BCM2711 pullups\n");
 		for (i = 0; i < db9_mode->gpio_num_inputs; i++)
 		{
-			pr_info("Using BCM2711 pullups\n");
 			int gpiopin = gpio_id[idx][i];
 			int pullreg = GPPUPPDN0 + (gpiopin >> 4);
 			int pullshift = (gpiopin & 0xf) << 1;

--- a/db9_gpio_rpi-1.2/db9_gpio_rpi.c
+++ b/db9_gpio_rpi-1.2/db9_gpio_rpi.c
@@ -717,7 +717,7 @@ static int __init db9_setup_pad(struct db9 *db9, int idx, int mode)
 			int pullreg = GPPUPPDN0 + (gpiopin >> 4);
 			int pullshift = (gpiopin & 0xf) << 1;
 			unsigned int pullbits;
-			unsigned int pull = 2; //0=none, 1=pullup, 2=pulldown
+			unsigned int pull = 1; //0 = none, 1 = pullup, 2 = pulldown
 			pullbits = *(gpio + pullreg);
 			pullbits &= ~(3 << pullshift);
 			pullbits |= (pull << pullshift);


### PR DESCRIPTION
Modified pullup routines to work with BCM2711.

Detection routine db9_bcm_model_probe() may not be very sophisticated. It takes "/compatible" from device tree and second index from it and assumes that it is in form "brcm,bcm2711".

Pullup routine is adapted from https://github.com/RPi-Distro/raspi-gpio/blob/master/raspi-gpio.c.